### PR TITLE
Properly convert Geth errors related to non-existent blocks into `BlockNotFound`

### DIFF
--- a/src/robust_provider/provider.rs
+++ b/src/robust_provider/provider.rs
@@ -434,8 +434,7 @@ impl<N: Network> RobustProvider<N> {
                         false
                     }
                     RpcError::Transport(tr_err) => tr_err.is_retry_err(),
-                    RpcError::DeserError { .. } => true,
-                    _ => false,
+                    _ => true,
                 })
                 .sleep(tokio::time::sleep),
         )


### PR DESCRIPTION
<!-- Append the issue number -->
Towards #12 

This is a quick-fix solution until #12 is investigated.

Removed `block_id` field from `BlockNotFound` for two reasons:
- **it's redundant** - the caller invokes provider's functions with a block id, and when the error is returned they already know the block id's value
- **it allows converting custom Geth RPC errors into `BlockNotFound` in [the `From` implementation](https://github.com/OpenZeppelin/Robust-Provider/pull/13/files#diff-ccfc5b365b4f693282550e2c47947b486c97ad2b05e625b40ff4550f50a69201R58)**
